### PR TITLE
Remove hard coded paths from URI

### DIFF
--- a/server/main.cpp
+++ b/server/main.cpp
@@ -147,9 +147,7 @@ crow::response data(const crow::request& req) {
     // 1. Find file
 
     try {
-       // H5::H5File hdf5("/home/sr2003/rds/rds-hpc-support-5mCMIDBOkPU/sr2003/UKAEA/Datafiles/" + uri_string, H5F_ACC_RDONLY);
-        //H5::H5File hdf5("/home/stefanie/work/adios/adiosnetwork/data/" + uri_string, H5F_ACC_RDONLY);
-        H5::H5File hdf5("/home/stefanie/work/adios/adiosnetwork/tests/test_data/" + uri_string, H5F_ACC_RDONLY);
+        H5::H5File hdf5(uri_string, H5F_ACC_RDONLY);
         CROW_LOG_DEBUG << "file"<< hdf5.getFileName();
         std::vector<ReturnData> return_data;
 


### PR DESCRIPTION
Hi,

I wanted to play with wands locally, but I am hindered by hardcoded paths in the server. Here's a quick PR to fix it.